### PR TITLE
feat(import-export): add pure functions for todo serialize/parse/validate

### DIFF
--- a/src/import-export.js
+++ b/src/import-export.js
@@ -1,0 +1,39 @@
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.ImportExport = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    function serialize(todos) {
+        return JSON.stringify(todos);
+    }
+
+    function parse(jsonString) {
+        return JSON.parse(jsonString);
+    }
+
+    function isTodo(value) {
+        return (
+            value !== null &&
+            typeof value === 'object' &&
+            typeof value.id === 'number' &&
+            typeof value.text === 'string' &&
+            typeof value.completed === 'boolean'
+        );
+    }
+
+    function validateImport(parsed) {
+        if (!Array.isArray(parsed)) {
+            return { valid: false, error: 'Expected an array of todos' };
+        }
+        for (let i = 0; i < parsed.length; i++) {
+            if (!isTodo(parsed[i])) {
+                return { valid: false, error: `Invalid todo at index ${i}` };
+            }
+        }
+        return { valid: true, todos: parsed };
+    }
+
+    return { serialize, parse, validateImport };
+}));

--- a/tests/import-export.test.js
+++ b/tests/import-export.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { serialize, parse, validateImport } = require('../src/import-export');
+
+const sample = [
+    { id: 1, text: 'a', completed: false },
+    { id: 2, text: 'b', completed: true },
+];
+
+test('serialize produces JSON parseable back to the same array', () => {
+    const out = serialize(sample);
+    assert.equal(typeof out, 'string');
+    assert.deepEqual(JSON.parse(out), sample);
+});
+
+test('serialize produces "[]" for an empty array', () => {
+    assert.equal(serialize([]), '[]');
+});
+
+test('parse returns the parsed value for valid JSON', () => {
+    assert.deepEqual(parse('[{"id":1,"text":"a","completed":false}]'), [
+        { id: 1, text: 'a', completed: false },
+    ]);
+});
+
+test('parse throws on invalid JSON', () => {
+    assert.throws(() => parse('{not json'));
+});
+
+test('validateImport accepts a well-formed todo array', () => {
+    const result = validateImport(sample);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.todos, sample);
+});
+
+test('validateImport rejects non-array input', () => {
+    const result = validateImport({ id: 1, text: 'a', completed: false });
+    assert.equal(result.valid, false);
+    assert.ok(result.error);
+});
+
+test('validateImport rejects items missing required fields', () => {
+    const result = validateImport([{ id: 1, text: 'a' }]);
+    assert.equal(result.valid, false);
+    assert.ok(result.error);
+});
+
+test('validateImport rejects items with wrong field types', () => {
+    const result = validateImport([{ id: 'x', text: 'a', completed: 'no' }]);
+    assert.equal(result.valid, false);
+    assert.ok(result.error);
+});


### PR DESCRIPTION
Closes #4.

## Zone
- `tests/import-export.test.js`
- `src/import-export.js`

## Changes
- Add `src/import-export.js` — UMD-hybrid module exposing pure `serialize`, `parse`, `validateImport` for both Node (`require`) and browser (`window.ImportExport`).
- Add `tests/import-export.test.js` — 8 `node:test` cases covering round-trip, empty array, invalid JSON, non-array input, missing fields, wrong types.
- No `app.js`/`index.html`/`styles.css` changes (those belong to T2 / #5).

## Budget
- Files: 2 / 2
- LOC: 91 / 120

## Verification
- Tests: 8/8 PASS (`node --test tests/import-export.test.js`)
- Zone boundary: PASS (only declared files modified)
- Pre-commit hooks: PASS

## Note
`npm test` is not yet wired in `package.json` (out of zone). Tests run directly via `node --test`. Wiring `npm test` is a follow-up — likely T2's scope or a separate infra task.